### PR TITLE
Add SlotUI composable

### DIFF
--- a/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/LevelUI.kt
+++ b/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/LevelUI.kt
@@ -1,18 +1,15 @@
 package com.anatideo.vehicleschemegenerator.presentation.composable
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import com.anatideo.vehicleschemegenerator.presentation.composable.SlotUI
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.anatideo.vehicleschemegenerator.data.model.Level
@@ -51,19 +48,7 @@ fun LevelUI(
                 Row {
                     repeat(level.columns) { colIndex ->
                         val cellIcon = iconByPosition[rowIndex to colIndex].orEmpty()
-                        Box(
-                            modifier = Modifier
-                                .size(42.dp)
-                                .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = cellIcon,
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    fontFamily = FontFamily.Monospace
-                                )
-                            )
-                        }
+                        SlotUI(slotIcon = cellIcon)
                     }
                 }
             }

--- a/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/SlotUI.kt
+++ b/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/SlotUI.kt
@@ -1,0 +1,39 @@
+package com.anatideo.vehicleschemegenerator.presentation.composable
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SlotUI(
+    slotIcon: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(42.dp)
+            .border(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = slotIcon,
+            style = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.Monospace
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun slotUIPreview() {
+    SlotUI(slotIcon = "🪑")
+}


### PR DESCRIPTION
## Summary
- introduce `SlotUI` composable for rendering slot icons
- refactor `LevelUI` to use `SlotUI`

## Testing
- `./gradlew test` *(fails: Starting a Gradle Daemon, 1 busy Daemon could not be reused)*

------
https://chatgpt.com/codex/tasks/task_e_6846dc6af3908329b7732b10550991d6