### PR TITLE
Add interactive 3D view

### DIFF
--- a/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/MainActivity.kt
+++ b/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/MainActivity.kt
@@ -5,13 +5,24 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.anatideo.vehicleschemegenerator.R
 import com.anatideo.vehicleschemegenerator.data.GetVehicleSchemeRepositoryImpl
 import com.anatideo.vehicleschemegenerator.data.datasource.mock.VehicleSchemeMockDataSourceImpl
 import com.anatideo.vehicleschemegenerator.data.model.VehicleScheme
 import com.anatideo.vehicleschemegenerator.core.ui.theme.AppTheme
 import com.anatideo.vehicleschemegenerator.data.model.Slot
 import com.anatideo.vehicleschemegenerator.presentation.composable.VehicleSchemeUI
+import com.anatideo.vehicleschemegenerator.presentation.composable.VehicleScheme3DUI
 import com.google.gson.GsonBuilder
 
 class MainActivity : ComponentActivity() {
@@ -22,7 +33,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             AppTheme {
-                VehicleSchemeUI(vehicleScheme, modifier = Modifier.fillMaxSize())
+                VehicleSchemeApp(vehicleScheme)
             }
         }
     }
@@ -67,6 +78,35 @@ class MainActivity : ComponentActivity() {
             }
 
             Log.d("VehicleScheme", "") // Add a space between decks for clarity
+        }
+    }
+}
+
+@Composable
+private fun VehicleSchemeApp(vehicleScheme: VehicleScheme) {
+    var show3D = remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(id = R.string.app_name)) },
+                actions = {
+                    val label = if (show3D.value) R.string.view_2d else R.string.view_3d
+                    TextButton(onClick = { show3D.value = !show3D.value }) {
+                        Text(stringResource(id = label))
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        val modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+
+        if (show3D.value) {
+            VehicleScheme3DUI(vehicleScheme, modifier)
+        } else {
+            VehicleSchemeUI(vehicleScheme, modifier)
         }
     }
 }

--- a/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/VehicleContent3DUI.kt
+++ b/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/VehicleContent3DUI.kt
@@ -1,0 +1,47 @@
+package com.anatideo.vehicleschemegenerator.presentation.composable
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.anatideo.vehicleschemegenerator.core.data.mock.VehicleSchemeMock
+import com.anatideo.vehicleschemegenerator.data.model.VehicleScheme
+
+@Composable
+fun VehicleContent3DUI(vehicleScheme: VehicleScheme) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Vehicle Type: ${'$'}{vehicleScheme.vehicleType}",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            vehicleScheme.decks.forEachIndexed { deckIndex, deck ->
+                DeckUI(
+                    deck = deck,
+                    deckIndex = deckIndex,
+                    modifier = Modifier.padding(bottom = 24.dp)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun vehicleContent3DUIPreview() {
+    VehicleContent3DUI(VehicleSchemeMock.mockCar())
+}

--- a/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/VehicleScheme3DUI.kt
+++ b/app/src/main/java/com/anatideo/vehicleschemegenerator/presentation/composable/VehicleScheme3DUI.kt
@@ -1,0 +1,49 @@
+package com.anatideo.vehicleschemegenerator.presentation.composable
+
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.graphicsLayer
+import com.anatideo.vehicleschemegenerator.data.model.VehicleScheme
+
+@Composable
+fun VehicleScheme3DUI(
+    vehicleScheme: VehicleScheme,
+    modifier: Modifier = Modifier
+) {
+    var rotX by remember { mutableStateOf(0f) }
+    var rotY by remember { mutableStateOf(0f) }
+    var scale by remember { mutableStateOf(1f) }
+
+    Surface(modifier, color = MaterialTheme.colorScheme.background) {
+        Box(
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTransformGestures { _, pan, zoom, _ ->
+                        rotY += pan.x
+                        rotX -= pan.y
+                        scale = (scale * zoom).coerceIn(0.5f, 3f)
+                    }
+                }
+                .graphicsLayer {
+                    rotationX = rotX
+                    rotationY = rotY
+                    scaleX = scale
+                    scaleY = scale
+                    cameraDistance = 12 * density
+                }
+        ) {
+            VehicleContent3DUI(vehicleScheme)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Vehicle Scheme Generator</string>
+    <string name="view_3d">3D View</string>
+    <string name="view_2d">2D View</string>
 </resources>


### PR DESCRIPTION
## Summary
- introduce new `VehicleScheme3DUI` and `VehicleContent3DUI` composables
- add a toolbar button to toggle 2D and 3D views
- wire up the new view in `MainActivity`
- add string resources for view labels

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee2c889c8329bfa57e92a3f957bf